### PR TITLE
Fix bug where sin_u16 behaves weird at its peaks

### DIFF
--- a/src/math/trig.rs
+++ b/src/math/trig.rs
@@ -8,7 +8,7 @@ pub fn sin_u16(theta: u16) -> i16 {
     static SLOPE: [u8; 8] = [49, 48, 44, 38, 31, 23, 14, 4];
     let mut offset = (theta & 0x3FFF) >> 3;
     if (theta & 0x4000) != 0 {
-        offset = 2057 - offset;
+        offset = 2047 - offset;
     }
 
     let section: u8 = (offset / 256) as u8;


### PR DESCRIPTION
sin16 currently produces weird results near its peaks (for example `sin16(16383) == 32645` but `sin16(16384) == 12337` where both of those should return `32645`). After some debugging and comparing to FastLED's original code, I discovered that it just seems to be a simple typo made when translating the code to Rust, and after changing this value it now seems to work correctly.